### PR TITLE
ci: group Dependabot minor/patch updates and cap open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,13 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule: { interval: weekly }
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }
+    groups:
+      actions:
+        update-types: [minor, patch]


### PR DESCRIPTION
## Summary

Tune the existing `.github/dependabot.yml` to reduce PR noise without losing coverage.

- **npm ecosystem:** add `open-pull-requests-limit: 5` and a `minor-and-patch` group so minor + patch bumps batch into one weekly PR per ecosystem. Majors still open separately for manual review.
- **github-actions ecosystem:** add an `actions` group for the same reason — routine bumps (`actions/checkout`, `actions/setup-node`, etc.) land as one PR rather than N.

## Why now

Dependabot already opened four ungrouped PRs on this repo (`bull-board/express`, `dotenv`, `@types/supertest`, `typescript`). Without grouping, each minor/patch bump becomes its own PR and review cycle; the queue swamps quickly on a small repo. This config turns those four into one batched PR per week.

Majors (e.g. Puppeteer, BullMQ, express) deliberately stay ungrouped so they get individual review — those are where most regressions hide.

## Test plan
- [ ] Merge this PR.
- [ ] Observe the next Dependabot run: minor/patch updates should arrive as a single grouped PR titled `chore(deps): bump the minor-and-patch group…`.
- [ ] Major bumps (if any) still open as separate PRs.
- [ ] Existing four open Dependabot PRs can be closed manually; the next run will re-propose them as a single group.