### PR TITLE
refactor: validate env at boot and harden /:jobId/url

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import pdfRoutes from './routes/pdf.route';
 import { errorHandler } from './middlewares/error-handler';
 import { setupQueueDashboard } from './monitoring/queues/bull-board';
-import 'dotenv/config';
 
 const app = express();
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,24 @@
+import 'dotenv/config';
+import { z } from 'zod';
+
+const envSchema = z.object({
+  AWS_ACCESS_KEY_ID: z.string().min(1),
+  AWS_SECRET_ACCESS_KEY: z.string().min(1),
+  AWS_REGION: z.string().min(1),
+  AWS_S3_BUCKET: z.string().min(1),
+  REDIS_HOST: z.string().min(1).default('localhost'),
+  REDIS_PORT: z.coerce.number().int().positive().default(6379),
+  PORT: z.coerce.number().int().positive().default(3000),
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  console.error(
+    '[Env][validate] Invalid environment variables:',
+    parsed.error.flatten().fieldErrors,
+  );
+  process.exit(1);
+}
+
+export const env = parsed.data;

--- a/src/config/redis.config.ts
+++ b/src/config/redis.config.ts
@@ -1,7 +1,8 @@
 import Redis from 'ioredis';
+import { env } from './env';
 
 export const redisClient = new Redis({
-  host: process.env.REDIS_HOST,
-  port: Number(process.env.REDIS_PORT) || 6379,
+  host: env.REDIS_HOST,
+  port: env.REDIS_PORT,
   maxRetriesPerRequest: null,
 });

--- a/src/config/s3.config.ts
+++ b/src/config/s3.config.ts
@@ -1,10 +1,10 @@
 import { S3Client } from '@aws-sdk/client-s3';
-import 'dotenv/config';
+import { env } from './env';
 
 export const s3 = new S3Client({
-  region: process.env.AWS_REGION,
+  region: env.AWS_REGION,
   credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
   },
 });

--- a/src/controllers/pdf.controller.ts
+++ b/src/controllers/pdf.controller.ts
@@ -38,9 +38,21 @@ const getPdfUrlByJobId = async (
     return;
   }
 
-  const { key } = job.returnvalue || {};
+  const state = await job.getState();
+
+  if (state === "failed") {
+    res.status(410).json({ error: "Job failed", reason: job.failedReason });
+    return;
+  }
+
+  if (state !== "completed") {
+    res.status(202).json({ status: state });
+    return;
+  }
+
+  const key = job.returnvalue?.key;
   if (!key) {
-    res.status(500).json({ error: "No key in job return value" });
+    res.status(500).json({ error: "Completed job is missing S3 key" });
     return;
   }
 

--- a/src/docs/CHANGES-round4.md
+++ b/src/docs/CHANGES-round4.md
@@ -1,0 +1,57 @@
+# Round 4 — Env validation & URL endpoint hardening
+
+Fourth pass over the codebase, driven by a code-quality audit. Focus: production readiness — fail fast on misconfiguration, surface job state correctly, tighten logging.
+
+---
+
+## `process.env.X!` non-null assertions across config
+
+`s3.config.ts`, `s3.service.ts`, `redis.config.ts`, and `server.ts` all read env vars with `!` or `||` fallbacks. A missing `AWS_*` var would not fail fast — the S3 client would initialize with `undefined` credentials and only blow up on the first upload, far from the actual misconfiguration.
+
+**Fix:** New `src/config/env.ts` validates the full environment at startup with zod. On failure it prints the offending keys via `flatten().fieldErrors` and calls `process.exit(1)`. All config and service modules import the typed `env` object instead of reaching into `process.env`. `server.ts` imports `env` first so validation runs before anything else in the app boots.
+
+Files: `src/config/env.ts` (new), `src/config/s3.config.ts`, `src/config/redis.config.ts`, `src/services/s3.service.ts`, `src/server.ts`.
+
+## Duplicate `dotenv/config` side-effect imports
+
+`import 'dotenv/config'` appeared in `app.ts`, `s3.config.ts`, and `s3.service.ts`. Node's module cache makes repeats harmless at runtime but confusing to read — three files looked responsible for loading env.
+
+**Fix:** `dotenv/config` is now imported exactly once, from the top of `src/config/env.ts`. Removed from the other three files.
+
+## `GET /:jobId/url` crashed on in-flight and failed jobs
+
+The handler read `job.returnvalue?.key` without checking job state. A still-running job returned a 500 saying "No key in job return value"; a failed job returned the same opaque 500 with no failure reason. Clients had no way to tell "still processing" from "permanently broken".
+
+**Fix:** Controller now calls `await job.getState()` first:
+
+- `failed` → 410 with `job.failedReason`
+- any non-`completed` state (`waiting`, `active`, `delayed`, …) → 202 with the current `status` so clients can poll
+- `completed` but missing key → 500 with a clearer message ("Completed job is missing S3 key")
+
+Files: `src/controllers/pdf.controller.ts`. Integration test mock updated to expose `getState`: `tests/integration/pdf.routes.test.ts`.
+
+## Worker failure logs lacked job context
+
+`pdfWorker.on('error')` logged without a job id, and there was no `failed` handler at all — making failed jobs hard to correlate in logs when triaging production issues.
+
+**Fix:** Added `pdfWorker.on('failed', (job, err) => …)` that includes `job?.id` in the prefix. Standardized the existing `error` handler's prefix to `[PdfWorker][error]` to match the project-wide `[Module][function]` convention.
+
+Files: `src/workers/pdf.worker.ts`.
+
+---
+
+## Files changed
+
+- `src/config/env.ts` (new)
+- `src/config/s3.config.ts`
+- `src/config/redis.config.ts`
+- `src/services/s3.service.ts`
+- `src/controllers/pdf.controller.ts`
+- `src/workers/pdf.worker.ts`
+- `src/app.ts`
+- `src/server.ts`
+- `tests/integration/pdf.routes.test.ts`
+
+## Verification
+
+`npx tsc --noEmit` — clean. `npm test` — 9/9 passing.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
+import { env } from './config/env';
 import app from './app';
 import { pdfWorker } from './workers/pdf.worker';
 import { closeBrowser } from './services/pdf.service';
 
-const PORT = process.env.PORT || 3000;
+const PORT = env.PORT;
 
 const server = app.listen(PORT, () => {
   console.log(`🚀 Server is running at http://localhost:${PORT}`);

--- a/src/services/s3.service.ts
+++ b/src/services/s3.service.ts
@@ -4,9 +4,9 @@ import { Readable, PassThrough } from "stream";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { s3 } from "../config/s3.config";
-import "dotenv/config";
+import { env } from "../config/env";
 
-const S3_BUCKET = process.env.AWS_S3_BUCKET!;
+const S3_BUCKET = env.AWS_S3_BUCKET;
 
 const uploadPdfToS3 = async (
   fileBuffer: Buffer,

--- a/src/workers/pdf.worker.ts
+++ b/src/workers/pdf.worker.ts
@@ -24,5 +24,9 @@ export const pdfWorker = new Worker(
 );
 
 pdfWorker.on("error", (err) => {
-  console.error("[PdfWorker] Worker error:", err);
+  console.error("[PdfWorker][error] Worker error:", err);
+});
+
+pdfWorker.on("failed", (job, err) => {
+  console.error(`[PdfWorker][failed] Job ${job?.id} failed:`, err);
 });

--- a/tests/integration/pdf.routes.test.ts
+++ b/tests/integration/pdf.routes.test.ts
@@ -7,7 +7,10 @@ const redisCache = vi.hoisted(() => new Map<string, string>());
 vi.mock("../../src/queues/queue", () => ({
   pdfQueue: {
     add: vi.fn().mockResolvedValue({ id: "job-1" }),
-    getJob: vi.fn().mockResolvedValue({ returnvalue: { key: "pdfs/test.pdf" } }),
+    getJob: vi.fn().mockResolvedValue({
+      returnvalue: { key: "pdfs/test.pdf" },
+      getState: vi.fn().mockResolvedValue("completed"),
+    }),
   },
 }));
 


### PR DESCRIPTION
## Summary
- Validate the full environment at startup with zod (`src/config/env.ts`); replace `process.env.X!` assertions in the S3 client, Redis client, S3 service, and server entrypoint so missing vars fail fast with a clear error instead of producing `undefined` credentials.
- Consolidate `dotenv/config` to a single import site (the new env module). Removed from `app.ts`, `s3.config.ts`, and `s3.service.ts`.
- Harden `GET /:jobId/url`: check `job.getState()` before reading `returnvalue`. Failed jobs now return `410` with `job.failedReason`; in-flight jobs return `202` with the current status; only `completed` jobs attempt to presign.
- Add `pdfWorker.on('failed', (job, err) => …)` with `job?.id` context for triage. Normalize the error-handler prefix to `[PdfWorker][error]` to match the project-wide `[Module][function]` convention.
- Update integration test mock to expose `getState` on the fake job.
- Document the round in `src/docs/CHANGES-round4.md`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 9/9 passing (existing coverage still exercises the presigned-URL happy path with the new state check)
- [ ] Manual smoke: boot with a missing `AWS_*` var and confirm the process exits with the offending field listed
- [ ] Manual smoke: hit `/pdf/:jobId/url` for an active, failed, and completed job — confirm `202`, `410`, and `200` respectively