### PR TITLE
feat: structured logging, request IDs, and dashboard basic auth

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,17 +1,26 @@
 import 'dotenv/config';
 import { z } from 'zod';
 
-const envSchema = z.object({
-  AWS_ACCESS_KEY_ID: z.string().min(1),
-  AWS_SECRET_ACCESS_KEY: z.string().min(1),
-  AWS_REGION: z.string().min(1),
-  AWS_S3_BUCKET: z.string().min(1),
-  REDIS_HOST: z.string().min(1).default('localhost'),
-  REDIS_PORT: z.coerce.number().int().positive().default(6379),
-  PORT: z.coerce.number().int().positive().default(3000),
-  BULL_BOARD_USER: z.string().min(1).optional(),
-  BULL_BOARD_PASSWORD: z.string().min(1).optional(),
-});
+const envSchema = z
+  .object({
+    AWS_ACCESS_KEY_ID: z.string().min(1),
+    AWS_SECRET_ACCESS_KEY: z.string().min(1),
+    AWS_REGION: z.string().min(1),
+    AWS_S3_BUCKET: z.string().min(1),
+    REDIS_HOST: z.string().min(1).default('localhost'),
+    REDIS_PORT: z.coerce.number().int().positive().default(6379),
+    PORT: z.coerce.number().int().positive().default(3000),
+    BULL_BOARD_USER: z.string().min(1).optional(),
+    BULL_BOARD_PASSWORD: z.string().min(1).optional(),
+  })
+  .refine(
+    (v) => !!v.BULL_BOARD_USER === !!v.BULL_BOARD_PASSWORD,
+    {
+      message:
+        'BULL_BOARD_USER and BULL_BOARD_PASSWORD must be set together (or both left unset)',
+      path: ['BULL_BOARD_USER'],
+    },
+  );
 
 const parsed = envSchema.safeParse(process.env);
 

--- a/src/middlewares/validate-content.middleware.ts
+++ b/src/middlewares/validate-content.middleware.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { RequestHandler } from 'express';
 import { z } from 'zod';
 
 const contentSchema = z.object({
@@ -7,7 +7,7 @@ const contentSchema = z.object({
     .max(50000, { message: 'Content too large' }),
 });
 
-export const validateContent: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
+export const validateContent: RequestHandler = (req, res, next) => {
   const validation = contentSchema.safeParse(req.body);
 
   if (!validation.success) {

--- a/tests/integration/pdf.routes.test.ts
+++ b/tests/integration/pdf.routes.test.ts
@@ -36,12 +36,15 @@ vi.mock("../../src/services/s3.service", () => ({
 // Import app after mocks
 import app from "../../src/app";
 import { pdfQueue } from "../../src/queues/queue";
-import { redisClient } from "../../src/config/redis.config";
 
 describe("PDF routes", () => {
   beforeEach(() => {
     redisCache.clear();
     vi.clearAllMocks();
+    (pdfQueue.getJob as any).mockResolvedValue({
+      returnvalue: { key: "pdfs/test.pdf" },
+      getState: vi.fn().mockResolvedValue("completed"),
+    });
   });
 
   it("POST /markdown - generates job from markdown content", async () => {
@@ -62,6 +65,17 @@ describe("PDF routes", () => {
     expect(res.body.error).toBe("Validation error: Required");
   });
 
+  it("POST /pdf - propagates x-request-id into job data", async () => {
+    await request(app)
+      .post("/pdf")
+      .set("x-request-id", "req-abc-123")
+      .send({ content: "<h1>Hello world</h1>" })
+      .expect(202);
+
+    const jobData = (pdfQueue.add as any).mock.calls[0][1];
+    expect(jobData.reqId).toBe("req-abc-123");
+  });
+
   it("GET /pdf/:jobId/url - returns presigned URL and caches it", async () => {
     const jobId = "job-123";
 
@@ -76,5 +90,43 @@ describe("PDF routes", () => {
     // getJob should not be called again because of cache
     expect(pdfQueue.getJob).toHaveBeenCalledTimes(1);
   });
-});
 
+  it("GET /pdf/:jobId/url - returns 404 when job does not exist", async () => {
+    (pdfQueue.getJob as any).mockResolvedValueOnce(undefined);
+
+    const res = await request(app).get("/pdf/missing/url").expect(404);
+    expect(res.body.error).toContain("missing");
+  });
+
+  it("GET /pdf/:jobId/url - returns 410 when job is failed", async () => {
+    (pdfQueue.getJob as any).mockResolvedValueOnce({
+      returnvalue: undefined,
+      failedReason: "Puppeteer crashed",
+      getState: vi.fn().mockResolvedValue("failed"),
+    });
+
+    const res = await request(app).get("/pdf/failed-job/url").expect(410);
+    expect(res.body.error).toBe("Job failed");
+    expect(res.body.reason).toBe("Puppeteer crashed");
+  });
+
+  it("GET /pdf/:jobId/url - returns 202 when job is still active", async () => {
+    (pdfQueue.getJob as any).mockResolvedValueOnce({
+      returnvalue: undefined,
+      getState: vi.fn().mockResolvedValue("active"),
+    });
+
+    const res = await request(app).get("/pdf/active-job/url").expect(202);
+    expect(res.body.status).toBe("active");
+  });
+
+  it("GET /pdf/:jobId/url - returns 500 when completed job has no S3 key", async () => {
+    (pdfQueue.getJob as any).mockResolvedValueOnce({
+      returnvalue: {},
+      getState: vi.fn().mockResolvedValue("completed"),
+    });
+
+    const res = await request(app).get("/pdf/no-key/url").expect(500);
+    expect(res.body.error).toContain("missing S3 key");
+  });
+});


### PR DESCRIPTION
Re-opening replacement for #15 (which was closed; branch recreated).

## Summary
- **Structured logging (pino).** Replaces all `console.*` with a single `logger`. `LOG_LEVEL` read directly from `process.env` so the logger module is independent of env validation. Default level is `silent` under `NODE_ENV=test`, `info` otherwise.
- **Request-ID correlation.** `requestContext` middleware attaches `req.id` (from `x-request-id` header or `randomUUID()`) and `req.log = logger.child({ reqId })`. Controller stamps `reqId` into BullMQ job data; worker builds a child logger keyed by `reqId` + `jobId` so enqueue → process → failure logs all correlate. `Express.Request` typed via `declare global`.
- **Bull Board basic auth.** `basic-auth.middleware.ts` uses `timingSafeEqual`. Mounted in front of `/queues` when both `BULL_BOARD_USER` and `BULL_BOARD_PASSWORD` are set. env.ts `refine` rejects half-configured pairs so a deploy with one set and one missing fails fast instead of booting unauthenticated. When both are unset the dashboard mounts for local dev with a `warn` log.
- **`POST /pdf` → 202 Accepted.** Matches its async semantics — the response carries a `jobId`; the client polls `/:jobId/url`. `/:jobId/url` retains its 200 / 202 / 410 / 404 / 500 mapping.
- **Test coverage expanded.** Integration tests now cover all `/:jobId/url` state branches (completed, active → 202, failed → 410, missing → 404, completed-with-no-key → 500) and verify that `x-request-id` propagates into BullMQ job data.
- **`validate-content.middleware.ts`** dropped redundant `Request/Response/NextFunction` imports — `RequestHandler` already types the callback.

## Env additions
- `BULL_BOARD_USER` + `BULL_BOARD_PASSWORD` — both-or-neither (enforced by zod refine)
- `LOG_LEVEL` — read by the logger module (pino level enum; no zod validation since the logger validates and falls back to a safe default)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 14/14 passing
- [ ] Manual: `curl -i localhost:3000/queues` → `401`; with `-u user:pass` → `200`
- [ ] Manual: boot with only `BULL_BOARD_USER` set → process exits with the refine error listing the offending field
- [ ] Manual: `curl -H 'x-request-id: abc-123' -X POST …` and confirm `abc-123` appears in both the enqueue log line and the worker's `start` / `done` lines