### PR TITLE
feat(cors): add CORS middleware gated by CORS_ORIGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ There is no build step (`tsconfig` has `noEmit: true`). For production, either r
 | `BULL_BOARD_PASSWORD` | no | — | If set, `BULL_BOARD_USER` must also be set. |
 | `TRUST_PROXY_HOPS` | no | `0` | Number of trusted reverse-proxy hops. Set to the actual hop count when running behind an LB so the rate limiter sees the real client IP. Never set higher than reality (spoof risk). |
 | `LOG_LEVEL` | no | `info` (`silent` under `NODE_ENV=test`) | `fatal`/`error`/`warn`/`info`/`debug`/`trace`/`silent`. |
+| `CORS_ORIGINS` | no | — | Comma-separated allowlist of origins permitted to call the API from a browser. Empty / unset = CORS middleware not mounted. Example: `http://localhost:5173,https://playground.example.com`. |
 
 ## Security notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@bull-board/api": "^6.9.6",
         "@bull-board/express": "^6.9.6",
         "bullmq": "^5.53.1",
+        "cors": "^2.8.6",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.4.1",
@@ -26,6 +27,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.2",
         "@types/sanitize-html": "^2.16.1",
         "@types/supertest": "^2.0.16",
@@ -2801,6 +2803,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3572,6 +3584,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -5288,6 +5317,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@bull-board/api": "^6.9.6",
     "@bull-board/express": "^6.9.6",
     "bullmq": "^5.53.1",
+    "cors": "^2.8.6",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.4.1",
@@ -30,6 +31,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.2",
     "@types/sanitize-html": "^2.16.1",
     "@types/supertest": "^2.0.16",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,17 @@
 import express from 'express';
+import cors from 'cors';
 import helmet from 'helmet';
 import pdfRoutes from './routes/pdf.route';
 import { errorHandler } from './middlewares/error-handler';
 import { requestContext } from './middlewares/request-context.middleware';
 import { setupQueueDashboard } from './monitoring/queues/bull-board';
 import { appRedisClient } from './config/redis.config';
+
+const parseCorsOrigins = (raw: string | undefined): string[] =>
+  (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 
 const app = express();
 
@@ -15,6 +22,21 @@ const app = express();
 const trustProxyHops = Number(process.env.TRUST_PROXY_HOPS);
 if (Number.isInteger(trustProxyHops) && trustProxyHops > 0) {
   app.set('trust proxy', trustProxyHops);
+}
+
+const corsOrigins = parseCorsOrigins(process.env.CORS_ORIGINS);
+if (corsOrigins.length > 0) {
+  app.use(
+    cors({
+      origin: (origin, cb) => {
+        if (!origin || corsOrigins.includes(origin)) {
+          cb(null, true);
+        } else {
+          cb(null, false);
+        }
+      },
+    }),
+  );
 }
 
 app.use(helmet());

--- a/tests/integration/cors.test.ts
+++ b/tests/integration/cors.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import request from "supertest";
+
+const { bullBoardMockFactory, s3ServiceMockFactory } = await vi.hoisted(
+  async () => await import("./mock-factories"),
+);
+
+vi.mock("../../src/queues/queue", () => ({
+  pdfQueue: { add: vi.fn(), getJob: vi.fn() },
+  PDF_QUEUE_NAME: "pdfGeneration",
+  PDF_JOB_NAME: "generatePdf",
+}));
+vi.mock("../../src/monitoring/queues/bull-board", bullBoardMockFactory);
+vi.mock("../../src/config/redis.config", () => ({
+  appRedisClient: {
+    get: vi.fn(),
+    setex: vi.fn(),
+    ping: vi.fn(async () => "PONG"),
+    quit: vi.fn(),
+  },
+  bullmqConnection: { quit: vi.fn() },
+}));
+vi.mock("../../src/services/s3.service", s3ServiceMockFactory);
+
+beforeAll(() => {
+  process.env.CORS_ORIGINS = "http://localhost:5173,https://playground.example.com";
+});
+
+const importApp = async () => (await import("../../src/app")).default;
+
+describe("CORS middleware", () => {
+  it("allows requests from origins in CORS_ORIGINS", async () => {
+    const app = await importApp();
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "http://localhost:5173");
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "http://localhost:5173",
+    );
+  });
+
+  it("rejects (omits header for) origins not in CORS_ORIGINS", async () => {
+    const app = await importApp();
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "https://evil.example.com");
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("responds 204 to preflight OPTIONS from allowed origin", async () => {
+    const app = await importApp();
+    const res = await request(app)
+      .options("/pdf")
+      .set("Origin", "http://localhost:5173")
+      .set("Access-Control-Request-Method", "POST")
+      .set("Access-Control-Request-Headers", "content-type");
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "http://localhost:5173",
+    );
+    expect(res.headers["access-control-allow-methods"]).toMatch(/POST/);
+  });
+});


### PR DESCRIPTION
Enables the upcoming html-to-pdf-frontend playground to call the API from a different origin. Empty CORS_ORIGINS keeps the middleware unmounted.